### PR TITLE
Changed release to publish a form3 docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ permissions:
 jobs:
   release:
     env:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ ifneq ($(GITHUB_REF_NAME),)
 endif
 
 build:
-	docker build -t andykuszyk/markasten:${TAG} .
+	docker build -t form3tech/markasten:${TAG} .
 
 login:
 	docker login -u "$(DOCKER_USERNAME)" -p "$(DOCKER_PASSWORD)"
 
 push:
-	docker push andykuszyk/markasten:${TAG}
-	docker tag andykuszyk/markasten:${TAG} andykuszyk/markasten:latest
-	docker push andykuszyk/markasten:latest
+	docker push form3tech/markasten:${TAG}
+	docker tag form3tech/markasten:${TAG} form3tech/markasten:latest
+	docker push form3tech/markasten:latest
 
 test:
 	go test ./... -v

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: white
 inputs:
   image:
-    default: "andykuszyk/markasten:latest"
+    default: "form3tech/markasten:latest"
     description: "The Markasten Docker image/tag to use"
   command:
     default: "tags"


### PR DESCRIPTION
Updated docker secrets in use, and also changed the user the image is published to. Also changed the image the action uses, so this fork can be used independently of the upstream.